### PR TITLE
fix: event logic

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,19 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "off"
+			},
+			"suspicious": {
+				"noArrayIndexKey": "off",
+				"noExplicitAny": "off",
+				"noConfusingVoidType": "off"
+			},
+			"correctness": {
+				"noUnusedImports": "warn",
+				"useExhaustiveDependencies": "off"
+			}
 		}
 	},
 	"javascript": {

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -112,7 +112,6 @@ const isFunction = (value: unknown) =>
 // https://github.com/LegendApp/legend-state/blob/main/src/react/useEffectOnce.ts
 
 export function useEffectOnce(
-  // biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
   effect: () => void | (() => void),
   deps: unknown[]
 ) {
@@ -121,14 +120,12 @@ export function useEffectOnce(
     process.env.NODE_ENV === "test"
   ) {
     const refDispose = useRef<{
-      // biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
       dispose?: void | (() => void);
       num: number;
     }>({
       num: 0,
     });
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
     useEffect(() => {
       // This is a hack to work around StrictMode running effects twice.
       // On the first run it returns a cleanup function that queues the dispose function


### PR DESCRIPTION
Use more reliable logic of creating an unique symbol for every instance of the group subscriber (children). This is safer than just increasing a count and decreasing for subscribing and unsubscribing respectively.